### PR TITLE
Sanitize carats from file name

### DIFF
--- a/lib/middleman-simple-thumbnailer/image.rb
+++ b/lib/middleman-simple-thumbnailer/image.rb
@@ -62,7 +62,7 @@ module MiddlemanSimpleThumbnailer
 
     def resized_image_name
       image_name.split('.').tap { |a| a.insert(-2, resize_to) }.join('.') # add resize_to sufix
-          .gsub(/[%@!<>]/, '>' => 'gt', '<' => 'lt')                      # sanitize file name
+          .gsub(/[%@!<>^]/, '>' => 'gt', '<' => 'lt')                     # sanitize file name
     end
 
     def abs_path

--- a/lib/middleman-simple-thumbnailer/image.rb
+++ b/lib/middleman-simple-thumbnailer/image.rb
@@ -67,7 +67,7 @@ module MiddlemanSimpleThumbnailer
 
     def resized_image_name
       image_name.split('.').tap { |a| a.insert(-2, resize_to) }.join('.') # add resize_to sufix
-          .gsub(/[%@!<>^]/, '>' => 'gt', '<' => 'lt')                     # sanitize file name
+          .gsub(/[%@!<>^]/, '>' => 'gt', '<' => 'lt', '^' => 'c')                     # sanitize file name
     end
 
     def abs_path


### PR DESCRIPTION
When resizing images to fit, I use a resize string such as `resize_to: '230x250^'`.  The carat is not a valid character for online filenames, and breaks stuff.

Adding it to the sanitization whitelist.