### PR TITLE
Support Middleman v4

### DIFF
--- a/lib/middleman-simple-thumbnailer/extension.rb
+++ b/lib/middleman-simple-thumbnailer/extension.rb
@@ -15,7 +15,7 @@ module MiddlemanSimpleThumbnailer
       @@is_development = app.development?
       app.after_build do |builder|
         MiddlemanSimpleThumbnailer::Image.all_objects.each do |image| 
-          builder.say_status :create, "#{image.resized_img_path}"
+          builder.thor.say_status :create, "#{image.resized_img_path}"
           image.save!
         end
       end

--- a/lib/middleman-simple-thumbnailer/extension.rb
+++ b/lib/middleman-simple-thumbnailer/extension.rb
@@ -12,6 +12,7 @@ module MiddlemanSimpleThumbnailer
 
     def initialize(app, options_hash={}, &block)
       super
+      @@is_development = app.development?
       app.after_build do |builder|
         MiddlemanSimpleThumbnailer::Image.all_objects.each do |image| 
           builder.say_status :create, "#{image.resized_img_path}"
@@ -31,7 +32,7 @@ module MiddlemanSimpleThumbnailer
         return super(path, options) unless resize_to
 
         image = MiddlemanSimpleThumbnailer::Image.new(path, resize_to, self.config)
-        if environment == :development
+        if @@is_development
           super("data:#{image.mime_type};base64,#{image.base64_data}", options)
         else
           super(image.resized_img_path, options)
@@ -39,6 +40,7 @@ module MiddlemanSimpleThumbnailer
       end
 
     end
+
   end
 end
 

--- a/lib/middleman-simple-thumbnailer/version.rb
+++ b/lib/middleman-simple-thumbnailer/version.rb
@@ -1,3 +1,3 @@
 module MiddlemanSimpleThumbnailer
-  VERSION = '1.0.2'
+  VERSION = '2.0.0'
 end

--- a/middleman-simple-thumbnailer.gemspec
+++ b/middleman-simple-thumbnailer.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {fixtures,features}/*`.split("\n")
   s.require_paths = ['lib']
   
-  s.add_runtime_dependency 'middleman-core', '~> 3'
+  s.add_runtime_dependency 'middleman-core', '~> 4'
   s.add_runtime_dependency 'mini_magick', '~> 4'
 
   s.add_development_dependency 'rake', '~> 10'


### PR DESCRIPTION
Hello!  First of all, thanks for your work on this Middleman extension. I think it is neat.

Currently this extension only support Middleman version 3, but version 4 has been released.   This PR adds support for Middleman v4 (at the expense of supporting v3).

Changes:

* Update version constraint on the `middleman-core` gem dependency to indicate that this gem is to be used with Middleman v4, not v3.
* Fix error with `environment` being undefined in Middleman v4.
* Fix error with `builder.say_status` being undefined - it is now `builder.thor.say_status`.
* Bumped version to 2.0.0 (as this no longer works with Middleman v3).

Let me know if this looks ok to you.   Thanks.

*Update: need to fix strange error with `expand_path` being undefined when running cukes.*