### PR TITLE
Improve Performance on local development platform

### DIFF
--- a/lib/middleman-simple-thumbnailer/extension.rb
+++ b/lib/middleman-simple-thumbnailer/extension.rb
@@ -50,7 +50,7 @@ module MiddlemanSimpleThumbnailer
           original_height = options.delete(:height)
           resized_height  = resize_to.split('x').last.to_i
           
-          if original_width <= resized_width
+          if !original_width.nil? && original_width <= resized_width
             if original_height <= resized_height
               options[:width] = original_width
             else

--- a/lib/middleman-simple-thumbnailer/extension.rb
+++ b/lib/middleman-simple-thumbnailer/extension.rb
@@ -37,12 +37,35 @@ module MiddlemanSimpleThumbnailer
       def image_tag(path, options={})
         resize_to = options.delete(:resize_to)
         return super(path, options) unless resize_to
+        ext = app.extensions[:middleman_simple_thumbnailer]
 
-        image = MiddlemanSimpleThumbnailer::Image.new(path, resize_to, app)
         if app.development?
-          super("data:#{image.mime_type};base64,#{image.base64_data}", options)
+
+          # For better performance on local development
+          # (high bandwidth)
+          # simply change width in <img>-tag
+          
+          original_width  = options.delete(:width)
+          resized_width   = resize_to.split('x').first.to_i
+          original_height = options.delete(:height)
+          resized_height  = resize_to.split('x').last.to_i
+          
+          if original_width <= resized_width
+            if original_height <= resized_height
+              options[:width] = original_width
+            else
+              options[:width] = original_width/original_height * resized_height
+            end
+          else
+            options[:width] = resized_width
+          end
+                    
+          super(path, options)
+          
         else
-          ext = app.extensions[:middleman_simple_thumbnailer]
+
+          image = MiddlemanSimpleThumbnailer::Image.new(path, resize_to, app)
+      
           ext.store_resized_image(path, resize_to)
           super(image.resized_img_path, options)
         end

--- a/lib/middleman-simple-thumbnailer/image.rb
+++ b/lib/middleman-simple-thumbnailer/image.rb
@@ -94,7 +94,7 @@ module MiddlemanSimpleThumbnailer
     end
 
     def cached_thumbnail_available?
-      File.exist?(cached_resized_img_abs_path)
+      File.exist?(cached_resized_img_abs_path) && (File.mtime(cached_resized_img_abs_path) >= File.mtime(abs_path))
     end
 
     def save_cached_thumbnail

--- a/lib/middleman-simple-thumbnailer/image.rb
+++ b/lib/middleman-simple-thumbnailer/image.rb
@@ -31,8 +31,12 @@ module MiddlemanSimpleThumbnailer
     end
 
     def save!
-      resize!
-      image.write(resized_img_abs_path)
+      if cached_thumbnail_available?
+        FileUtils.cp cached_resized_img_abs_path, resized_img_abs_path
+      else
+        resize!
+        image.write(resized_img_abs_path)
+      end
     end
 
     def self.options=(options)

--- a/lib/middleman-simple-thumbnailer/image.rb
+++ b/lib/middleman-simple-thumbnailer/image.rb
@@ -35,6 +35,7 @@ module MiddlemanSimpleThumbnailer
         FileUtils.cp cached_resized_img_abs_path, resized_img_abs_path
       else
         resize!
+        save_cached_thumbnail
         image.write(resized_img_abs_path)
       end
     end


### PR DESCRIPTION
Hi,

I'm unexperienced on Github. So I'm not sure if a _pull request_ is the right kind of message to ask for a code change.

I develop on a small laptop, so bandwidth is not a problem, but cpu is scarce. When using hundreds of images that are rather large (850px width), I get very large blog-post sizes. That really slowed down the articles-overview to the point where it took minutes to display the page.

That's why I replaced the base64 inline image with the original image but only different width in the img-tag.

Also, because I use hundreds of image-files, it saves a lot of time to simply reuse the cached images. Why did you remove that feature? You wrote, that it feels safer. Maybe we can add an option for that?
