### PR TITLE
Add an image_path helper

### DIFF
--- a/lib/middleman-simple-thumbnailer/extension.rb
+++ b/lib/middleman-simple-thumbnailer/extension.rb
@@ -35,16 +35,24 @@ module MiddlemanSimpleThumbnailer
     helpers do
 
       def image_tag(path, options={})
+        if (resize_to = options.delete(:resize_to))
+          super(image_path(path, resize_to: resize_to), options)
+        else
+          super(path, options)
+        end
+      end
+
+      def image_path(path, options={})
         resize_to = options.delete(:resize_to)
-        return super(path, options) unless resize_to
+        return super(path) unless resize_to
 
         image = MiddlemanSimpleThumbnailer::Image.new(path, resize_to, app)
         if app.development?
-          super("data:#{image.mime_type};base64,#{image.base64_data}", options)
+          super("data:#{image.mime_type};base64,#{image.base64_data}")
         else
           ext = app.extensions[:middleman_simple_thumbnailer]
           ext.store_resized_image(path, resize_to)
-          super(image.resized_img_path, options)
+          super(image.resized_img_path)
         end
       end
 


### PR DESCRIPTION
Registers images to build thumbnails and provides paths to those thumbnails for use in linking to alternate sources like in the case of `srcset`.

``` html
<picture>
  <source srcset="<%= image_path "cowsay.jpg", resize_to: 1200 %>" media="(min-width: 900px)">
  <%= image_tag "cowsay.jpg", resize_to: 400 %>
</picture>
```

References: [MDN picture element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture), [MDN img element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img)
