### PR TITLE
Save and copy all resized images from the cache

### DIFF
--- a/lib/middleman-simple-thumbnailer/image.rb
+++ b/lib/middleman-simple-thumbnailer/image.rb
@@ -31,8 +31,12 @@ module MiddlemanSimpleThumbnailer
     end
 
     def save!
-      resize!
-      image.write(resized_img_abs_path)
+      unless cached_thumbnail_available?
+        resize!
+        save_cached_thumbnail
+      end
+
+      FileUtils.copy_file(cached_resized_img_abs_path, resized_img_abs_path)
     end
 
     def self.options=(options)


### PR DESCRIPTION
Save all resized images to the cache directory. When building the site reuse the cached files instead of recreating them each build.

After the first build, this provides a significant decrease in built time.
