### PR TITLE
Resolving image_tag issue

### DIFF
--- a/lib/middleman-simple-thumbnailer/extension.rb
+++ b/lib/middleman-simple-thumbnailer/extension.rb
@@ -36,23 +36,31 @@ module MiddlemanSimpleThumbnailer
 
       def image_tag(path, options={})
         if (resize_to = options.delete(:resize_to))
-          super(image_path(path, resize_to: resize_to), options)
+          super(image_name(path, resize_to), options)
         else
           super(path, options)
         end
       end
 
       def image_path(path, options={})
-        resize_to = options.delete(:resize_to)
-        return super(path) unless resize_to
+        if (resize_to = options.delete(:resize_to))
+          super(image_name(path, resize_to))
+        else
+          super(path)
+        end
+      end
+
+      #  returns data or modified image name
+      def image_name(path, resize_to=nil)
+        return path unless resize_to
 
         image = MiddlemanSimpleThumbnailer::Image.new(path, resize_to, app)
         if app.development?
-          super("data:#{image.mime_type};base64,#{image.base64_data}")
+          "data:#{image.mime_type};base64,#{image.base64_data}"
         else
           ext = app.extensions[:middleman_simple_thumbnailer]
           ext.store_resized_image(path, resize_to)
-          super(image.resized_img_path)
+          image.resized_img_path
         end
       end
 

--- a/lib/middleman-simple-thumbnailer/image.rb
+++ b/lib/middleman-simple-thumbnailer/image.rb
@@ -52,11 +52,7 @@ module MiddlemanSimpleThumbnailer
     end
 
     def middleman_abs_path
-      if @app.extensions[:relative_assets].nil?
-        img_path.start_with?('/') ? img_path : File.join(images_dir, img_path)
-      else 
-        img_path
-      end
+      img_path.start_with?('/') ? img_path : File.join(images_dir, img_path)
     end
 
 

--- a/lib/middleman-simple-thumbnailer/image.rb
+++ b/lib/middleman-simple-thumbnailer/image.rb
@@ -52,7 +52,11 @@ module MiddlemanSimpleThumbnailer
     end
 
     def middleman_abs_path
-      img_path.start_with?('/') ? img_path : File.join(images_dir, img_path)
+      if @app.extensions[:relative_assets].nil?
+        img_path.start_with?('/') ? img_path : File.join(images_dir, img_path)
+      else 
+        img_path
+      end
     end
 
 


### PR DESCRIPTION
It looks like in the original code for `extension.rb` image_tag (when resizing) was calling the super method on the result from `image_path`. When relative_assets is activated, this leads to the `images_dir` being added to the path twice. *I think*.

I've resolved it here by having a separate function `image_name` that either modifies the image name or returns the base64 data, then calling super on the result of this from both `image_path` and `image_tag`.

I think ideally, this would not be another helper method, but I'm not sure how to achieve this. I also haven't added any tests as I'm pretty new to ruby. This currently passes the existing tests though.
 