### PR TITLE
Fix for out of date thumbnails

### DIFF
--- a/lib/middleman-simple-thumbnailer/extension.rb
+++ b/lib/middleman-simple-thumbnailer/extension.rb
@@ -82,7 +82,7 @@ module MiddlemanSimpleThumbnailer
           resize_specs_modified = true
         end
         img = MiddlemanSimpleThumbnailer::Image.new(img_path, resize_to, builder.app, options)
-        if !File.exists?(img.resized_img_abs_path)
+        if !img.cached_thumbnail_available? or !File.exists?(img.resized_img_abs_path)
           builder.thor.say_status :create, "#{img.resized_img_abs_path}"
           img.save!
         end

--- a/lib/middleman-simple-thumbnailer/image.rb
+++ b/lib/middleman-simple-thumbnailer/image.rb
@@ -63,6 +63,10 @@ module MiddlemanSimpleThumbnailer
       }.join('.')
     end
 
+    def cached_thumbnail_available?
+      File.exist?(cached_resized_img_abs_path)
+    end
+
     private
 
     def resize!
@@ -95,10 +99,6 @@ module MiddlemanSimpleThumbnailer
 
     def abs_path
       File.join(source_dir, middleman_abs_path)
-    end
-
-    def cached_thumbnail_available?
-      File.exist?(cached_resized_img_abs_path)
     end
 
     def save_cached_thumbnail

--- a/lib/middleman-simple-thumbnailer/version.rb
+++ b/lib/middleman-simple-thumbnailer/version.rb
@@ -1,3 +1,3 @@
 module MiddlemanSimpleThumbnailer
-  VERSION = '1.4.0'
+  VERSION = '1.4.1'
 end


### PR DESCRIPTION
In this edit I've tried to fix an issue where thumbnails in the built site are out of date.

The previous behaviour was to only copy thumbnails to the build directory in the `after_build` function if the thumbnail did not exist. However, it is possible that this thumbnail is out of date (if the original image has been updated).

In the fix, I now check also if `cached_thumbnail_available?`. This will return false if there is no cached thumbnail (or if the current cached thumbnail is out of date). In this occurs (or if the thumbnail does not exist) we should copy the thumbnail (after creating a new cached version, which happens with the `save!` method.
